### PR TITLE
Make qb PHP7 compatible

### DIFF
--- a/README.html
+++ b/README.html
@@ -1,4 +1,4 @@
-<!-- This is invalid HTML, intentionally.
+<!-- This is an incomplete HTML page, intentionally.
      If you are reading this on GitHub, find
      the beautiful version at http://scytale.name/proj/qb/ -->
 <p>qb is a blog system by <a href="http://scytale.name/">Tim 'Scytale' Weber</a> for people who:</p>
@@ -12,6 +12,7 @@
 	<strong>Warning:</strong>
 	Since October 12, 2008, qb has no maintainer and is not actively developed or supported.
 	However, the current codebase works fine and there are no known security issues.
+	(It has even been made PHP7 compatible in 2019!)
 	You are encouraged to become qb's new maintainer if you think it is worth it.
 </p>
 <p>
@@ -22,7 +23,7 @@
 
 <h2>System Requirements</h2>
 <ul>
-	<li><a href="http://php.net/">PHP 5</a></li>
+	<li><a href="http://php.net/">PHP 5.3 or higher</a></li>
 	<li><a href="http://httpd.apache.org/">Apache Web Server</a> or <a href="http://www.lighttpd.net/">lighttpd</a> (others not tested)</li>
 	<li>Unix-based OS (others not tested)</li>
 </ul>

--- a/lib/qb-0.2.php
+++ b/lib/qb-0.2.php
@@ -279,7 +279,9 @@ function qb_runpattern($pattern, $string) {
 	foreach ($pattern as $k => $v) {
 		if (!is_array($v)) {
 			// This !is_array() is to catch the "tags" variable.
-			$string = preg_replace($k, $v, $string);
+			$string = (is_object($v) && $v instanceof \Closure)
+				? preg_replace_callback($k, $v, $string)
+				: preg_replace($k, $v, $string);
 		}
 	}
 	return ($string);
@@ -310,9 +312,9 @@ function qb_template($template, $data) {
 	// Create a regex that will apply to all other <qb:ifnotset:...> tags.
 	$regex['|<qb:ifnotset:([a-z0-9]+) *>(.*)</qb:ifnotset:\\1 *>|Us'] = '$2';
 	// Create a regex for the date magic.
-	$regex['|<qb:date>([0-9]+) *([^<>]+)</qb:date>|me'] = "date('\$2', \$1)";
+	$regex['|<qb:date>([0-9]+) *([^<>]+)</qb:date>|m'] = function ($m) { return date($m[2], $m[1]); };
 	// Create a regex for the path magic.
-	$regex['|<qb:cleanpath>([^<>]+)</qb:cleanpath>|me'] = "preg_replace('|/+|', '/', '\$1')";
+	$regex['|<qb:cleanpath>([^<>]+)</qb:cleanpath>|m'] = function ($m) { return preg_replace('|/+|', '/', $m[1]); };
 	// Merge the generated and the configured regexes. Configured ones overwrite
 	// generated ones.
 	$regex = array_merge($regex, $qb_regex);


### PR DESCRIPTION
The only thing I had to do was getting rid of the `/e` flag to `preg_replace`; I'm now using closures and `preg_replace_callback` for the two regexes that needed it. This increases qb's system requirements to PHP ≥ 5.3.